### PR TITLE
Nova 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nova4 TinyMCE Editor
+# Nova TinyMCE Editor
 
 <p align="center">
 <img src="https://github.com/murdercode/Nova4-TinymceEditor/raw/HEAD/art/banner.svg" width="100%" 
@@ -40,7 +40,8 @@ alt="Demo Nova4 TinyMce"></p>
 
 This package follows the following versioning scheme:
 
-* **v1.x** - TinyMCE 5 or 6
+* **v2.x** - Nova 5 - TinyMCE 5 or 6
+* **v1.x** - Nova 4 - TinyMCE 5 or 6
 * **v0.x** - TinyMCE version 5 (deprecated)
 
 ## Prerequisites
@@ -291,6 +292,16 @@ Also, you must change the format of the plugin snippet in `nova-tinymce-editor` 
             // etc...
         ],
 ```
+
+## Upgrade from Nova 4 to Nova 5
+
+To upgrade this package for use with Nova 5, update your composer.json to use version 2:
+
+```bash
+composer require murdercode/nova4-tinymce-editor:^2.0
+```
+
+The v2.x branch is fully compatible with Nova 5 while maintaining all the features from v1.x. No additional configuration changes are needed.
 
 ## Feedback and Support
 

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.0",
-        "laravel/nova": "^4.0"
+        "php": "^8.0|^8.1|^8.2|^8.3|^8.4",
+        "laravel/nova": "^4.0|^5.0"
     },
     "require-dev": {
         "laravel/pint": "^1.2",


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `composer.json` files to support the new version of the Nova TinyMCE Editor package compatible with Nova 5. The key changes include updating versioning information, adding upgrade instructions, and modifying the composer requirements.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Changed the package name from "Nova4 TinyMCE Editor" to "Nova TinyMCE Editor".
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R44): Updated versioning scheme to include Nova 5 compatibility and added instructions for upgrading from Nova 4 to Nova 5. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R296-R305)

Composer updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L12-R13): Updated the PHP version requirements to include versions 8.1 through 8.4, and added support for Laravel Nova 5.